### PR TITLE
Fix interpreter link error

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -13,8 +13,8 @@ $(BUILDDIR)/libminivm.a: $(BUILDDIR)/minivm.o
 $(BUILDDIR)/minivm.o: minivm.c
 	$(CC) $(CFLAGS) -g -c minivm.c -o $@
 
-$(BUILDDIR)/interpreter: interpreter.c
-	$(CC) $(CFLAGS) -g $(BUILDDIR)/libminivm.a interpreter.c -o $@
+$(BUILDDIR)/interpreter: interpreter.c $(BUILDDIR)/libminivm.a
+	$(CC) $(CFLAGS) -g $^ -o $@
 
 clean:
 	rm -rf $(BUILDDIR)


### PR DESCRIPTION
Fixes the build error reported by https://github.com/KAIST-IS521/2017-Spring/issues/64
Now it works in Ubuntu 16.04 LTS, gcc 5.4.0.