### PR TITLE
Add usage printing, type checking and fix one parsing error

### DIFF
--- a/compiler/compiler.ml
+++ b/compiler/compiler.ml
@@ -4,7 +4,7 @@
    To run: ocaml str.cma compiler.ml <asm file> <output file>
 *)
 
-type line = { no : int; content : string}
+type line = {num : int; content : string}
 
 let max_oprs = 3
 let max_int = 0xff (* Maximum integer supported for this asm language *)
@@ -17,7 +17,7 @@ let usage () =
   print_endline "Usage : ocaml str.cma compiler.ml <asm file> <output file>"
 
 let error line msg =
-  Printf.printf "[Errror] Line %d : %s\n    %s\n" line.no msg line.content;
+  Printf.printf "[Errror] Line %d : %s\n    %s\n" line.num msg line.content;
   exit 1
 
 let opcode_to_int = function
@@ -82,8 +82,7 @@ let out oc opcode operands =
 let check_range num_str line =
   try
     let num = int_of_string num_str in
-    if num < 0 || num > max_int then
-      error line "Invalid integer range"
+    if num < 0 || num > max_int then error line "Invalid integer range"
   with Failure _ -> error line "Invalid integer format"
 
 let check_reg_range = check_range
@@ -121,14 +120,14 @@ let parse inpath outpath =
   let ic = open_in inpath in
   let oc = open_out outpath in
   try
-    let line_no = ref 0 in
+    let line_num = ref 0 in
     while true do
       let l = input_line ic in
-      let _ = line_no := !line_no + 1 in
-      let line = {no = !line_no; content = l} in
+      line_num := !line_num + 1;
+      let line = {num = !line_num; content = l} in
       match Str.split space l with
-      | opcode :: operands_str ->
-        let operands = Str.split delim (String.concat "" operands_str) in
+      | opcode :: tail_tokens ->
+        let operands = Str.split delim (String.concat "" tail_tokens) in
         type_check opcode operands line;
         out oc opcode operands
       | [] -> error line "empty line provided"

--- a/compiler/compiler.ml
+++ b/compiler/compiler.ml
@@ -1,13 +1,16 @@
 (*
    Mini Language Compiler (Assembler)
 
-   To run: ocaml str.cma compiler.ml <asm file>
+   To run: ocaml str.cma compiler.ml <asm file> <output file>
 *)
 
 let max_oprs = 3
 let delim = Str.regexp "\\( \\|\t\\)*,\\( \\|\t\\)*"
 let reg = Str.regexp "r\\([0-9]+\\)"
 let imm = Str.regexp "[0-9]+"
+
+let usage () =
+  print_endline "Usage : ocaml str.cma compiler.ml <asm file> <output file>"
 
 let opcode_to_int = function
   | "halt" -> 0x00
@@ -70,5 +73,5 @@ let parse inpath outpath =
   with End_of_file -> (close_in ic; close_out oc)
 
 let main =
-  if Array.length Sys.argv < 3 then exit 1
+  if Array.length Sys.argv <> 3 then (usage(); exit 1)
   else parse Sys.argv.(1) Sys.argv.(2)

--- a/compiler/compiler.ml
+++ b/compiler/compiler.ml
@@ -10,7 +10,7 @@ let max_oprs = 3
 let max_int = 0xff (* Maximum integer supported for this asm language *)
 let space = Str.regexp "\\( \\|\t\\)+"
 let delim = Str.regexp "\\( \\|\t\\)*,\\( \\|\t\\)*"
-let reg = Str.regexp "r\\([0-9]+\\)"
+let reg = Str.regexp "r\\([0-9]+\\)$"
 let imm = Str.regexp "[0-9]+"
 
 let usage () =

--- a/compiler/compiler.ml
+++ b/compiler/compiler.ml
@@ -4,6 +4,8 @@
    To run: ocaml str.cma compiler.ml <asm file> <output file>
 *)
 
+type line = { no : int; content : string}
+
 let max_oprs = 3
 let space = Str.regexp "\\( \\|\t\\)+"
 let delim = Str.regexp "\\( \\|\t\\)*,\\( \\|\t\\)*"
@@ -12,6 +14,10 @@ let imm = Str.regexp "[0-9]+"
 
 let usage () =
   print_endline "Usage : ocaml str.cma compiler.ml <asm file> <output file>"
+
+let error line msg =
+  Printf.printf "[Errror] Line %d : %s\n\t%s" line.no msg line.content;
+  exit 1
 
 let opcode_to_int = function
   | "halt" -> 0x00
@@ -53,15 +59,24 @@ let out oc opcode operands =
   List.iter (out_operand oc) operands;
   out_no_opr oc (max_oprs - List.length operands)
 
+(* Check if the types (reg/imm) of operands are valid *)
+let check_type operand operands line =
+  (* TODO : fill in *)
+  ()
+
 let parse inpath outpath =
   let ic = open_in inpath in
   let oc = open_out outpath in
   try
+    let line_no = ref 0 in
     while true do
       let l = input_line ic in
+      let _ = line_no := !line_no + 1 in
+      let line = {no = !line_no; content = l} in
       match Str.split space l with
       | opcode :: operands_str ->
           let operands = Str.split delim (String.concat "" operands_str) in
+          check_type opcode operands line;
           out oc opcode operands
       | _ -> failwith "Str.Split failure"
     done


### PR DESCRIPTION
- Print usage if the number of argument provided to compiler.ml is invalid.
- Emit compile error when input assembly code has type errors (wrong # of operand, wrong type of operand, etc.).
- Fix a bug where register string with trailing characters (e.g. "r100aaa") was not properly rejected.